### PR TITLE
Prevent URI parser from removing query strings

### DIFF
--- a/hprose/client/asio/HproseHTTPClient.hpp
+++ b/hprose/client/asio/HproseHTTPClient.hpp
@@ -179,12 +179,9 @@ private:
             }
         }
         SetHeader("Host", (ipv6 ? ('[' + host + ']') : host) + ((port == "80") ? std::string() : (':' + port)));
-        x = surl.find('?');
-        if (x != std::string::npos) {
-            path = '/' + surl.substr(0, x);
-        } else {
-            path = '/' + surl;
-        }
+        
+        path = '/' + surl;
+        
         if (host == "") {
             host = "localhost";
         }


### PR DESCRIPTION
The service URI may be compromised after being parsed by `ParseURI()`, losing its query string.

In a real world scenario, the caller should be able to prepare its service URI with/without proper query string subject to preexisting designs. It is neither responsible nor beneficial for this API to remove the query string in the http client API.

This patch preserve the query string in `path`.