### PR TITLE
Omit argument list if empty

### DIFF
--- a/hprose/client/HproseClient.hpp
+++ b/hprose/client/HproseClient.hpp
@@ -191,7 +191,9 @@ private:
         HproseWriter writer(stream);
         stream << HproseTags::TagCall;
         writer.WriteString(name, false);
-        writer.WriteList(args, false);
+        if (!args.empty()) {
+            writer.WriteList(args, false);
+        }
         if (ref) {
             writer.WriteBool(true);
         }
@@ -203,7 +205,9 @@ private:
         HproseWriter writer(stream);
         stream << HproseTags::TagCall;
         writer.WriteString(name, false);
-        writer.WriteList(args, false);
+        if (!args.empty()) {
+            writer.WriteList(args, false);
+        }
         if (ref) {
             writer.WriteBool(true);
         }

--- a/hprose/client/HproseClient.hpp
+++ b/hprose/client/HproseClient.hpp
@@ -202,7 +202,9 @@ private:
     void DoOutput(const std::string & name, ArgsType (&args)[ArraySize], bool ref, std::ostream & stream) {
         HproseWriter writer(stream);
         stream << HproseTags::TagCall;
-        writer.WriteString(name, false);
+        if (!args.empty()) {
+            writer.WriteString(name, false);
+        }
         writer.WriteList(args, false);
         if (ref) {
             writer.WriteBool(true);

--- a/hprose/client/HproseClient.hpp
+++ b/hprose/client/HproseClient.hpp
@@ -191,7 +191,9 @@ private:
         HproseWriter writer(stream);
         stream << HproseTags::TagCall;
         writer.WriteString(name, false);
-        writer.WriteList(args, false);
+        if (!args.empty()) {
+            writer.WriteList(args, false);
+        }
         if (ref) {
             writer.WriteBool(true);
         }
@@ -202,10 +204,10 @@ private:
     void DoOutput(const std::string & name, ArgsType (&args)[ArraySize], bool ref, std::ostream & stream) {
         HproseWriter writer(stream);
         stream << HproseTags::TagCall;
+        writer.WriteString(name, false);
         if (!args.empty()) {
-            writer.WriteString(name, false);
+            writer.WriteList(args, false);
         }
-        writer.WriteList(args, false);
         if (ref) {
             writer.WriteBool(true);
         }


### PR DESCRIPTION
In serialization, if argument list of an RPC call is empty, skip its list of argument.