### PR TITLE
Fix a runtime error of method call `empty()`.

### DIFF
--- a/hprose/client/HproseClient.hpp
+++ b/hprose/client/HproseClient.hpp
@@ -206,7 +206,7 @@ private:
         HproseWriter writer(stream);
         stream << HproseTags::TagCall;
         writer.WriteString(name, false);
-        if (!args.empty()) {
+        if (ArraySize > 0) {
             writer.WriteList(args, false);
             if (ref) {
                 writer.WriteBool(true);


### PR DESCRIPTION
Determine size of `args` with `ArraySize`.