### PR TITLE
Unserialize Empty elements in a list.

### DIFF
--- a/hprose/io/HproseReader.hpp
+++ b/hprose/io/HproseReader.hpp
@@ -412,6 +412,7 @@ private:
             case HproseTags::TagNaN: return std::numeric_limits<double>::quiet_NaN();
             case HproseTags::TagInfinity: return ReadInfinityWithoutTag();
             case HproseTags::TagNull: return Any();
+            case HproseTags::TagEmpty: return std::string();
             case HproseTags::TagTrue: return true;
             case HproseTags::TagFalse: return false;
             case HproseTags::TagDate: return ReadDateWithoutTag();


### PR DESCRIPTION
Current implementation would not handle 'e' tags in a List context, leading to an exception and break the unserialization process. In this commit an empty element is converted to a zero-byte std::string instance.